### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/gnu-data.yml
+++ b/.github/workflows/gnu-data.yml
@@ -19,10 +19,10 @@ jobs:
         sudo apt-get install jq python3-pandas python3-matplotlib
 
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Download the result
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v3
       with:
         workflow: compat.yml
         name: gnu-result
@@ -43,7 +43,7 @@ jobs:
        rm -rf dl
 
     - name: Add & Commit
-      uses: EndBug/add-and-commit@v7.2.1
+      uses: EndBug/add-and-commit@v9.1.4
       with:
         default_author: github_actions
         message: "Update of the GNU data"
@@ -55,7 +55,7 @@ jobs:
         python graph.py gnu-result.json
 
     - name: Add & Commit the graph
-      uses: EndBug/add-and-commit@v7.2.1
+      uses: EndBug/add-and-commit@v9.1.4
       with:
         default_author: github_actions
         message: "Refresh the graph"
@@ -72,10 +72,10 @@ jobs:
         sudo apt-get install jq python3-pandas python3-matplotlib
 
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Download the result
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v3
       with:
         workflow: compat.yml
         name: bfs-result
@@ -96,7 +96,7 @@ jobs:
        rm -rf dl
 
     - name: Add & Commit
-      uses: EndBug/add-and-commit@v7.2.1
+      uses: EndBug/add-and-commit@v9.1.4
       with:
         default_author: github_actions
         message: "Update of the BFS data"
@@ -108,7 +108,7 @@ jobs:
         python graph.py bfs-result.json
 
     - name: Add & Commit the graph
-      uses: EndBug/add-and-commit@v7.2.1
+      uses: EndBug/add-and-commit@v9.1.4
       with:
         default_author: github_actions
         message: "Refresh the graph"


### PR DESCRIPTION
This PR updates the following actions: `checkout` from `v2` to `v4`, `action-download-artifact` from `v2` to `v3`, and `EndBug` from `v7.2.1` to `v9.1.4`. It should fix the deprecation warnings about old `nodejs` versions.