### PR TITLE
ci: use "pull" instead of "pull_strategy"

### DIFF
--- a/.github/workflows/gnu-data.yml
+++ b/.github/workflows/gnu-data.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         default_author: github_actions
         message: "Update of the GNU data"
-        pull_strategy: '--autostash'
+        pull: '--autostash'
 
     - name: Generate the graph
       shell: bash
@@ -100,7 +100,7 @@ jobs:
       with:
         default_author: github_actions
         message: "Update of the BFS data"
-        pull_strategy: '--autostash'
+        pull: '--autostash'
 
     - name: Generate the graph
       shell: bash


### PR DESCRIPTION
This PR should fix the warning below I introduced in https://github.com/uutils/findutils-tracking/pull/3 with the update of `EndBug`.
```
Unexpected input(s) 'pull_strategy', valid inputs are ['add', 'author_name', 'author_email', 'commit', 'committer_name', 'committer_email', 'cwd', 'default_author', 'fetch', 'message', 'new_branch', 'pathspec_error_handling', 'pull', 'push', 'remove', 'tag', 'tag_push', 'github_token']
```