### PR TITLE
Updated CI to save SVG graphs

### DIFF
--- a/.github/workflows/gnu-data.yml
+++ b/.github/workflows/gnu-data.yml
@@ -59,7 +59,7 @@ jobs:
       with:
         default_author: github_actions
         message: "Refresh the graph"
-        add: gnu-results.png
+        add: gnu-results.svg
 
   bfs:
     name: Process the BFS test results
@@ -112,4 +112,4 @@ jobs:
       with:
         default_author: github_actions
         message: "Refresh the graph"
-        add: bfs-results.png
+        add: bfs-results.svg


### PR DESCRIPTION
* Updated CI to save the SVG graphs. Fixup after #7

Also see for coreutils: https://github.com/uutils/coreutils-tracking/pull/25